### PR TITLE
Enable trello integration for user stories

### DIFF
--- a/user-stories/index.md
+++ b/user-stories/index.md
@@ -17,6 +17,6 @@ A set of user stories to inform development of the Data at Work ecosystem.
 
 User stories for are managed on a Trello board which you can view below.  Click through to leave a comment or subscribe to user stories you're interested in.
 
-<iframe width="100%" height="725px" src="https://trello.com/b/WPPGNArj"></iframe>
+<iframe width="100%" height="725px" src="https://trello.com/b/WPPGNArj.html"></iframe>
 
 


### PR DESCRIPTION
Trello blocks embedding the way we were attempting it before. If you add an html to the URL it gives you a static version that works.