### PR TITLE
Cleanup

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ url: "http://dataatwork.org" # the base hostname & protocol for your site
 github_username:  workforce-data-initiative
 github_repo:  dataatwork.org
 paypal: admin@dataatwork.org
-contact: http://discuss.dataatwork.org/c/dataatwork
+contact: http://dataatwork.org/get-involved/#contact
 editsitehowto: /about/edit-site/
 gems:
   - jekyll-redirect-from

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
 
   <div>
     <div class="primary">
-      <a href="https://uchicago.edu/" rel="external"><img src="{{ "/img/uchicago_logo_grey.jpg" | prepend: site.baseurl }}" width="123" height="32" alt="Open Knowledge"></a>
+      <a href="https://uchicago.edu/" rel="external"><img src="{{ "/img/uchicago_logo_grey.jpg" | prepend: site.baseurl }}" width="123" height="32" alt="University of Chicago"></a>
       
       {% if site.supporters %}
       <div class="supporters">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
 
   <div>
     <div class="primary">
-      <a href="https://okfn.org/" rel="external"><img src="{{ "/img/uchicago_logo_grey.jpg" | prepend: site.baseurl }}" width="123" height="32" alt="Open Knowledge"></a>
+      <a href="https://uchicago.edu/" rel="external"><img src="{{ "/img/uchicago_logo_grey.jpg" | prepend: site.baseurl }}" width="123" height="32" alt="Open Knowledge"></a>
       
       {% if site.supporters %}
       <div class="supporters">
@@ -14,15 +14,6 @@
         {% endfor %}
       </div>
       {% endif %}
-    </div>
-    
-    <div class="secondary">
-      <ul>
-        <li><a href="/get-involved/#newsletter">Newsletter</a></li>
-        <li><a href="https://okfn.org/terms-of-use/" rel="external">Terms of use</a></li>
-        <li><a href="https://okfn.org/privacy-policy/" rel="external">Privacy policy</a></li>
-        <li class="button"><a href="http://opendefinition.org/" rel="external"><img src="{{ site.baseurl }}/img/open-content.svg" width="80" height="15" alt="Open Content"/></a></li>
-      </ul>
     </div>
     
     <div class="tertiary">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,10 +36,6 @@
       <a href="{{ site.baseurl }}/roadmap/">Roadmap</a>
     </li>
     
-    <li {% if url_last ==  'guides' %}class="Selected"{% endif %}>
-      <a href="{{ site.baseurl }}/guides/">Guides</a>
-    </li>
-
     <li {% if url_last ==  'get-involved' %}class="Selected"{% endif %}>
       <a href="{{ site.baseurl }}/get-involved/">Get Involved</a>
     </li>
@@ -56,12 +52,8 @@
       <a href="{{ site.baseurl }}/case-studies/">Case Studies</a>
     </li>
     
-    <li {% if url_last ==  'blog' %}class="Selected"{% endif %}>
-      <a href="http://okfnlabs.org/blog/">Blog</a>
-    </li>
-    
     <li>
-      <a href="https://api.dataatwork.org/v1/spec/">
+      <a href="http://api.dataatwork.org/v1/spec/">
         Specifications
       </a>
     </li>

--- a/get-involved/index.html
+++ b/get-involved/index.html
@@ -2,7 +2,7 @@
 title: Get Involved
 ---
 
-<p>Data at Work is a major project of <a href="https://dsapp.org/">the University of Chicago's Center for Data Science and Public Policy</a>, the Department of Labor, the National Skills Coalition, and a large set of community stakeholders.  Community building continues to be a core component of the project: <strong>anyone can get involved and contributions are very welcome</strong>.</p>
+<p>Data at Work is a major project of <a href="https://dsapp.uchicago.edu/">the University of Chicago's Center for Data Science and Public Policy</a>, the Department of Labor, the National Skills Coalition, and a large set of community stakeholders.  Community building continues to be a core component of the project: <strong>anyone can get involved and contributions are very welcome</strong>.</p>
 
 <p>In order to make creating, using, and sharing workforce data as easy and frictionless as possible, we need <strong>concrete use cases</strong> and <strong>feedback</strong> from people working across government, industry, and academia:</p>
 
@@ -11,28 +11,16 @@ title: Get Involved
   <li>Are you a developer working on an application to help people find jobs that our <a href="{{ site.baseurl }}/standards/">standards</a> should support?
 </ul>
 
-<p><a href="http://dataatwork.org/contact">Let us know</a>.  We’d love to hear about it. For examples of data that's already been made available, see the <a href="{{ site.baseurl }}/data/">data</a> page. For examples of what has already been built, see the <a href="{{ site.baseurl }}/tools/">tools</a> page.  For information on where we’re going, see our <a href="{{ site.baseurl }}/roadmap/">roadmap</a>.</p>
-
-<p>We're also <a href="http://okfnlabs.org/blog/2015/01/03/data-curators-wanted-for-core-datasets.html">looking for volunteer "curators"</a> interested in helping us create a set of high quality, useful skills to help us improve the skills data and associated algorithms.</p>
+<p><a href="{{ site.contact }}">Let us know</a>.  We’d love to hear about it. For examples of data that's already been made available, see the <a href="{{ site.baseurl }}/data/">data</a> page. For examples of what has already been built, see the <a href="{{ site.baseurl }}/tools/">tools</a> page.  For information on where we’re going, see our <a href="{{ site.baseurl }}/roadmap/">roadmap</a>.</p>
 
 <h2 id="contact">Contact</h2>
 
 <p>If you're not sure where to start, there are lots of ways to get in contact with the core team members as well as the broader community around Data at Work</p>
 
-<h3 id="forum">Forum</h3>
-
-<p>If you have a use case that you'd like to see Data at Work support, leave a note in the <a href="https://discuss.okfn.org/c/frictionless-data">forum</a>.</p>
-
 <h3 id="chat">Chat</h3>
 
-<p>We also have a <a href="https://workforcedatainitiative.slack.com">and open slack organization</a> dedicated to technical discussion about Open Skills and Training Provider Outcomes Tools.  Feel free to stop by and introduce yourself and join the conversation.</p>
+<p>We have an <a href="http://slack.dataatwork.org">open slack organization</a> dedicated to technical discussion about Open Skills and Training Provider Outcomes Tools.  Feel free to stop by and introduce yourself and join the conversation.</p>
 
 <h3 id="github">GitHub</h3>
 
-<p>All code developed in support of this project is hosted on the <a href="https://github.com/workforcedatainitiative/">workforce data initiative</a> organization on GitHub.  Comments, forks, and pull requests welcome.</p>
-
-<h3 id="newsletter">Newsletter</h3>
-
-<p>Sign up for our newsletter to receive updates on tooling or specification releases, events, and other news related to Data at Work.</p>
-  
-{% include newsletter.html %}
+<p>All code developed in support of this project is hosted on the <a href="https://github.com/workforce-data-initiative/">workforce-data-initiative</a> organization on GitHub.  Comments, forks, and pull requests welcome.</p>


### PR DESCRIPTION
Since we're about to start sending out this URL a bunch more, I thought it was time to do long-needed cleanup

- Fix UChicago logo link, remove Terms/Privacy for which we have no copy [Resolves #13]
- Remove Guides/Blog links which just go to OpenKnowledge [Resolves #11]
- Remove Newsletter section from Get Involved page [Resolves #10]
- Remove 'curators wanted' link from OpenKnowledge [Resolves #9]
- Fix contact config url and section on Get Involved page [Resolves #7]
- Fix dsapp link [Resolves #6]
- Fix slack link [Resolves #5]
- Fix github org link [Resolves #4]